### PR TITLE
Add `.Rmd` script to convert raw data to valid Camera Trap Data Package

### DIFF
--- a/src/insectai_to_camtrapdp.Rmd
+++ b/src/insectai_to_camtrapdp.Rmd
@@ -1,0 +1,414 @@
+---
+title: "insectai_to_camtrapdp"
+author: 
+- "Sanne Govaert"
+date: "`r Sys.Date()`"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+# Install packages
+
+Before beginning, you need to ensure that all required R packages are installed. This includes packages for data handling, working with frictionless data, and the development version of `camtrapdp` from GitHub.
+
+```{r}
+# Install required packages if not already installed
+rlang::check_installed(c(
+  "here",
+  "dplyr",
+  "frictionless",
+  "camtrapdp"
+))
+```
+
+
+## Load libraries
+
+Next, load all the necessary libraries.
+
+```{r}
+library(here)
+library(dplyr)
+library(frictionless)
+library(camtrapdp)
+```
+
+# Import data
+
+Import the raw data. This/these file(s) contains the source data that will be transformed into a Camtrap DP.
+
+```{r}
+datasetname_name <- NA_character_ # eg. "rangex", this will be used to save the files in the correct folders, at the end of the script
+# data <-
+```
+
+Probably the data will need to be pre-processed before it can be mapped to Camtrap DP. This can include cleaning, filtering, or transforming the data to fit the structure required by Camtrap DP. Here is an example: https://github.com/camera-traps/bioacoustics/blob/main/datasets/sound_of_norway/src/acoustic_to_camtrapdp_sound-of-norway.Rmd
+
+```{r}
+# data <-
+```
+
+# Create resources
+
+Create the five resources (deployments, media, observations, detections, models) based on the pre-proccessed data.
+
+## Create deployments resource
+
+```{r}
+deployments <-
+  data |> 
+  dplyr::mutate(
+    deploymentID = NA_character_, # Required
+    locationID = NA_character_,
+    locationName = NA_character_,
+    latitude = NA_real_, # Required
+    longitude = NA_real_, # Required
+    coordinateUncertainty = NA_integer_,
+    deploymentStart = NA_character_, # Required | YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss±hh:mm
+    deploymentEnd = NA_character_, # Required | YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss±hh:mm
+    setupBy = NA_character_,
+    cameraID = NA_character_,
+    cameraModel = NA_character_,
+    cameraDelay = NA_integer_,
+    cameraHeight = NA_real_,
+    cameraDepth = NA_real_,
+    cameraTilt = NA_integer_,
+    cameraHeading = NA_integer_,
+    detectionDistance = NA_real_,
+    timestampIssues = NA_character_,
+    attractantUse = NA,
+    atttractantType = NA_character_,
+    featureType = NA_character_,
+    habitat = NA_character_,
+    deploymentGroups = NA_character_,
+    deploymentTags = NA_character_,
+    deploymentComments = NA_character_,
+    .keep = "none"
+  ) |> 
+  dplyr::arrange(deploymentID) |>
+  dplyr::select(
+    deploymentID, locationID, locationName, latitude, longitude,
+    coordinateUncertainty, deploymentStart, deploymentEnd, setupBy, cameraID,
+    cameraModel, cameraDelay, cameraHeight, cameraDepth, cameraTilt,
+    cameraHeading, detectionDistance, timestampIssues, attractantUse,
+    atttractantType, featureType, habitat, deploymentGroups, deploymentTags,
+    deploymentComments
+    )
+```
+
+## Create media resource
+
+```{r}
+media <-
+  data |> 
+  dplyr::mutate(
+    mediaID = NA_character_, # Required
+    deploymentID = NA_character_, # Required
+    captureMethod = NA_character_,
+    timestamp = NA_character_, # Required | YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss±hh:mm
+    filePath = NA_character_, # Required
+    filePublic = NA, # Required
+    fileName = NA_character_,
+    fileMediatype = NA_character_, # Required
+    exifData = NA_character_,
+    favorite = NA_character_,
+    mediaComments = NA_character_,
+    .keep = "none"
+  ) |> 
+  dplyr::arrange(mediaID) |>
+  dplyr::select(
+    mediaID, deploymentID, captureMethod, timestamp, filePath, filePublic,
+    fileName, fileMediatype, exifData, favorite, mediaComments
+    )
+```
+
+## Create observations resource
+
+```{r}
+observations <-
+  data |> 
+  dplyr::mutate(
+    observationID = NA_character_, # Required
+    deploymentID = NA_character_, # Required
+    mediaID = NA_character_,
+    eventID = NA, # If empty, set to NA to be able to use read_camtrapdp(), see https://github.com/inbo/camtrapdp/issues/162
+    eventStart = NA_character_, # Required
+    eventEnd = NA_character_, # Required
+    observationLevel = NA_character_, # Required
+    observationType = NA_character_, # Required 
+    cameraSetupType = NA_character_,
+    scientificName = NA_character_,  # Required
+    count = NA_integer_,
+    lifeStage = NA_character_,
+    sex = NA_character_,
+    behavior = NA_character_,
+    individualID = NA_character_,
+    individualPositionRadius = NA_real_,
+    individualPositionAngle = NA_real_,
+    individualSpeed = NA_real_,
+    bboxX = NA_real_,
+    bboxY = NA_real_,
+    bboxWidth = NA_real_,
+    bboxHeight = NA_real_,
+    classificationMethod = NA_character_,
+    classifiedBy = NA_character_,
+    classificationTimestamp = NA_character_,
+    classificationProbability = NA_real_,
+    observationTags = NA_character_,
+    observationComments = NA_character_,
+    .keep = "none"
+  ) |> 
+  dplyr::arrange(observationID) |>
+  dplyr::select(
+    observationID, deploymentID, mediaID, eventID, eventStart, eventEnd,
+    observationLevel, observationType, cameraSetupType, scientificName,
+    count, lifeStage, sex, behavior, individualID, individualPositionRadius,
+    individualPositionAngle, individualSpeed, bboxX, bboxY, bboxWidth,
+    bboxHeight, classificationMethod, classifiedBy, classificationTimestamp,
+    classificationProbability, observationTags, observationComments
+  )
+```
+
+## Create detections resource
+
+```{r}
+detections <-
+  data |> 
+  dplyr::mutate(
+    detectionID = NA_character_, # Required
+    detectionsourceID = NA_character_,
+    observationID = NA_character_,
+    deploymentID = NA_character_, # Required
+    mediaID = NA_character_,
+    eventID = NA,
+    eventStart = NA_character_, # Required
+    eventEnd = NA_character_, # Required
+    detectionLevel = NA_character_, # Required
+    detectionType = NA_character_, # Required 
+    cameraSetupType = NA_character_,
+    scientificName = NA_character_,  # Required
+    count = NA_integer_,
+    lifeStage = NA_character_,
+    sex = NA_character_,
+    behavior = NA_character_,
+    individualID = NA_character_,
+    individualPositionRadius = NA_real_,
+    individualPositionAngle = NA_real_,
+    individualSpeed = NA_real_,
+    bboxX = NA_real_,
+    bboxY = NA_real_,
+    bboxWidth = NA_real_,
+    bboxHeight = NA_real_,
+    classificationMethod = NA_character_,
+    classifiedBy = NA_character_,
+    modelID = NA_character_, 
+    classificationTimestamp = NA_character_,
+    classificationProbability = NA_real_,
+    detectionsTags = NA_character_,
+    detectionComments = NA_character_,
+    .keep = "none"
+  ) |> 
+  dplyr::arrange(detectionID) |>
+  dplyr::select(
+    detectionID, detectionsourceID, observationID, deploymentID, mediaID,
+    eventID, eventStart, eventEnd, detectionLevel, detectionType,
+    cameraSetupType, scientificName, count, lifeStage, sex, behavior,
+    individualID, individualPositionRadius, individualPositionAngle,
+    individualSpeed, bboxX, bboxY, bboxWidth, bboxHeight, classificationMethod,
+    classifiedBy, modelID, classificationTimestamp, classificationProbability,
+    detectionsTags, detectionComments
+  )
+```
+
+## Create models resource
+
+```{r}
+models <-
+  data |>
+  dplyr::mutate(
+    modelID = NA_character_, # Required
+    modelName = NA_character_, 
+    modelVersion = NA_character_,
+    modelDescription = NA_character_,
+    modelPathRpository = NA_character_, # Required
+    publicationDate = NA_character_, # YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss±hh:mm
+    modelTask = NA_character_,
+    .keep = "none"
+  ) |>
+  dplyr::arrange(modelID) |>
+  dplyr::select(
+    modelID, modelName, modelVersion, modelDescription, modelPathRpository,
+    publicationDate, modelTask
+  )
+```
+
+
+# Create data package
+
+A Camtrap DP is a Frictionless Data Package that consists of
+- datapackage.json: Metadata about the data package and camera trap project.
+- deployments.csv: Table with camera trap placements (deployments).
+- media.csv: Table with media files recorded during deployments.
+- observations.csv: Table with observations derived from the media files.
+
+For the insectai adaptation, two more resources are added:
+- detecions.csv
+- models.csv
+
+Start with compiling the five resources into a frictionless data package, adding metadata such as schema files and project information.
+
+```{r}
+package <-
+  frictionless::create_package() |>
+  frictionless::add_resource(
+    resource_name = "deployments",
+    data = deployments,
+    schema = "https://raw.githubusercontent.com/camera-traps/insectai/refs/heads/main/camtrap-dp/deployments-table-schema-insectai.json"
+    ) |>
+  frictionless::add_resource(
+    resource_name = "media",
+    data = media,
+    schema = "https://raw.githubusercontent.com/camera-traps/insectai/refs/heads/main/camtrap-dp/media-table-schema-insectai.json"
+    ) |>
+  frictionless::add_resource(
+    resource_name = "observations",
+    data = observations,
+    schema = "https://raw.githubusercontent.com/camera-traps/insectai/refs/heads/main/camtrap-dp/observations-table-schema-insectai.json"
+    ) |>
+  frictionless::add_resource(
+    resource_name = "detections",
+    data = detections,
+    schema = "https://raw.githubusercontent.com/camera-traps/insectai/refs/heads/main/camtrap-dp/detections-table-schema-insectai.json"
+    )|>
+  frictionless::add_resource(
+    resource_name = "models",
+    data = models,
+    schema = "https://raw.githubusercontent.com/camera-traps/insectai/refs/heads/main/camtrap-dp/models-table-schema-insectai.json"
+    ) |>
+  append(c(
+    name = "camtrap-dp-insectai-example-dataset", # Required
+    profile = "https://github.com/camera-traps/insectai/blob/main/camtrap-dp/camtrap-dp-profile-insectai.json", # Required
+    id = NULL,
+    created = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"), # Required
+    title = NULL,
+    description = NULL,
+    version = "1.0",
+    keywords = NULL,
+    image = NULL,
+    homepage = NULL,
+    sources = NULL,
+    bibliographicCitation = NULL,
+    coordinatePrecision = NULL,
+    spatial = NULL, # Required, but keep this empty, this comes later
+    temporal = NULL, # Required, but keep this empty, this comes later
+    taxonomic = NULL, # Required, but keep this empty, this comes later
+    relatedIdentifiers = NULL,
+    references = NULL
+  )) |>
+  frictionless::create_package()
+```
+
+Then add contributor information, licenses, and project metadata to complete the package description.
+
+```{r}
+package$contributors <- list( # Required
+  list(
+    title = NULL,
+    email = NULL,
+    path = NULL,
+    role = NULL,
+    organization = NULL
+  )
+)
+
+package$licenses <- list(
+  list(
+    name = "CC0-1.0",
+    scope = "data" # Required
+  ),
+  list(
+    path = "http://creativecommons.org/licenses/by/4.0/",
+    scope = "media" # Required
+  )
+)
+
+package$project <- list( # Required
+  # id = "",
+  title = NULL, # Required
+  # acronym = "",
+  description = NULL,
+  protocolType = NULL, # Required
+  samplingDesign = NULL, # Required
+  # path = NULL,
+  captureMethod = NULL, # Required
+  individualAnimals = NULL, # Required
+  observationLevel = NULL # Required
+)
+```
+
+## Add taxonomic coverage
+
+Create a function to format taxonomy rows for inclusion in the metadata, then apply it to the data.
+The code is to simply add all scientific names.
+You can also add the whole taxonomy and vernacular names to the metadata, see https://camtrap-dp.tdwg.org/metadata/#taxonomic.
+
+```{r}
+taxonomyy <- data |> 
+  dplyr::select(scientificName) |>
+  dplyr::distinct()
+
+map_taxonomy <- function(taxonomy) {
+  list(
+    scientificName = taxonomy$scientificName,
+    taxonRank = "species"
+  )
+}
+```
+
+```{r}
+taxonomy_list <- apply(taxonomy, 1, as.list)
+package$taxonomic <- purrr::map(taxonomy_list, map_taxonomy)
+```
+
+Or you can also simplify it by only providing higher taxonomic levels, eg:
+
+```{r}
+taxonomic_coverage <-
+  data.frame(
+    scientificName = "Insecta",
+    taxonRank = "class"
+    )
+package$taxonomic <- taxonomic_coverage
+```
+
+# Write Data Package
+
+## Create frictionless data package
+
+Save the frictionless data package, including all resources and metadata, to the designated interim directory.
+
+```{r}
+# `here` works within an R project, which is not the case yet for this repository. So adapt if necessary!
+frictionless::write_package(package, here::here("datasets", datasetname_name, "data-interim"))
+```
+
+## Read with camtrapdp
+
+Now, read the Camtrap DP data package to automatically update the spatial, temporal, and taxonomic coverage fields in the metadata based on the resources.
+
+```{r}
+package_v2 <- camtrapdp::read_camtrapdp(here::here("datasets", datasetname_name, "data-interim", "datapackage.json"))
+```
+
+## Write Camtrap DP
+
+Finally, write the completed Camera Trap Data Package to the processed directory.
+
+```{r}
+camtrapdp::write_camtrapdp(package_v2, here::here("datasets", datasetname_name))
+```
+
+This final DP can be validated against the specifications of Camtrap DP (and Frictionless Data Package). See https://camtrap-dp.tdwg.org/#validation.


### PR DESCRIPTION
This PR adds an `.Rmd` script to convert raw data to a Camera Trap Data Package that can be [validated](https://camtrap-dp.tdwg.org/#validation) against the "insectai" specifications of Camtrap DP (and Frictionless Data Package) with Python.

Some remarks:
- I was not sure where it belongs in the repo structure, so I now created a new folder `src`. Or is there a better place?
- This script has not been used yet with real data, so I am sure there will be mistakes that need to be fixed.
- The data package uses the Camtrap DP profiles and schema's that are updated for the insectai suggestions, living [here](https://github.com/camera-traps/insectai/tree/main/camtrap-dp). The json files are valid, but there might be mistakes in the content, as these schema's have not been used to validate a real dataset yet. It is part of the data mapping exercise to find out of the profile and schema's do the right thing.
- 3 terms have not been included, as it is ambiguous in the report (`individualLength`, `individualBiomass`, `consensusProtocolRule`). These are included in the report tables but not explicitly mentioned as new suggested terms.