### PR TITLE
Add URL path protection

### DIFF
--- a/.github/scripts/validate_datasets.py
+++ b/.github/scripts/validate_datasets.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from typing import Any, Callable
 import re
+from urllib.parse import quote_plus
 import os
 
 from frictionless import validate, Report, Error
@@ -179,9 +180,9 @@ def extract_readme_image(dataset_path: Path) -> str | None:
             mtch = re.match(image_path_embed_pattern, first_line)
             if not mtch:
                 return None
-            mtch = mtch.group(1)
+            mtch = mtch.group(1).strip()
             image_path = dataset_path.joinpath(*mtch.split("/"))
-            return "/" + str(image_path)
+            return "/".join(map(quote_plus, str(image_path).strip().split(os.sep)))
     except Exception:
         pass
     return None

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@
 | [**amber**](/datasets/amber) | 🔴 Failed (1/5) | _No image tag found_ |
 | [**antenna**](/datasets/antenna) | 🟠 Partial (2/5) | _No image tag found_ |
 | [**diopsis**](/datasets/diopsis) | 🟠 Partial (2/5) | _No image tag found_ |
-| [**flatbug**](/datasets/flatbug) | 🟠 Partial (3/7) | <img src="/datasets/flatbug/raw-data/ALUS/Araneae_Unknown_2020_11_10_4723.jpg " height="150"> |
+| [**flatbug**](/datasets/flatbug) | 🟠 Partial (3/7) | <img src="datasets/flatbug/raw-data/ALUS/Araneae_Unknown_2020_11_10_4723.jpg" height="150"> |
 | [**flower_visitors**](/datasets/flower_visitors) | 🔴 Failed (1/5) | _No image tag found_ |
-| [**ias**](/datasets/ias) | 🟡 Almost (3/5) | <img src="/datasets/ias/raw-data/20250613022959-snapshot.jpg " height="150"> |
+| [**ias**](/datasets/ias) | 🟡 Almost (3/5) | <img src="datasets/ias/raw-data/20250613022959-snapshot.jpg" height="150"> |
 | [**insect-detect**](/datasets/insect-detect) | 🔴 Failed (1/5) | _No image tag found_ |
 | [**lepmon**](/datasets/lepmon) | 🟠 Partial (2/5) | _No image tag found_ |
-| [**minimon**](/datasets/minimon) | 🟡 Almost (3/5) | <img src="/datasets/minimon/media/E41990/20250614/E41990_20250614094103_0105_012989.jpg " height="150"> |
+| [**minimon**](/datasets/minimon) | 🟡 Almost (3/5) | <img src="datasets/minimon/media/E41990/20250614/E41990_20250614094103_0105_012989.jpg" height="150"> |
 | [**plant-pollinator-interactions**](/datasets/plant-pollinator-interactions) | 🔴 Failed (1/5) | _No image tag found_ |
-| [**rangex**](/datasets/rangex) | 🟢 Success (5/5) | <img src="/datasets/rangex/media/HE22_01_83_2037_2.jpg " height="150"> |
+| [**rangex**](/datasets/rangex) | 🟢 Success (5/5) | <img src="datasets/rangex/media/HE22_01_83_2037_2.jpg" height="150"> |
 
-<!-- Last updated: 2026-04-21 08:18:37 UTC -->
+<!-- Last updated: 2026-04-21 09:38:00 UTC -->
 <!-- END: DATASET PROGRESS TABLE -->
 ---
 


### PR DESCRIPTION
Fix special characters in example image paths breaking README table (e.g. `"#"`)