### PR TITLE
fix(flower_visitors): align datapackage.json with Camtrap DP 1.0.2

### DIFF
--- a/datasets/flower_visitors/code/data_conversion.py
+++ b/datasets/flower_visitors/code/data_conversion.py
@@ -4,6 +4,15 @@ Proposed Camtrap DP conversion for flower_visitors minidataset.
 This script was run locally from: .../example-datasets/datasets/flower_visitors/code/
 A Python enviornment with the packages listed in requirements.txt is required to run it end-to-end.
 
+Example of bash code in terminal (Linux - Ubuntu)
+```bash
+# Assuming 
+source /home/vs66tavy/Nextcloud/InsectAI_COST_Serbia/.venv/bin/activate
+cd example-datasets/datasets/flower_visitors/code/
+python3 data_conversion.py
+frictionless validate ../datapackage.json
+```
+
 Outputs (in the parent dataset folder .../example-datasets/datasets/flower_visitors/) are:
     - deployments.csv
     - media.csv
@@ -595,7 +604,7 @@ datapackage = {
             "format": "csv",
             "mediatype": "text/csv",
             "encoding": "utf-8",
-            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json",
+            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/deployments-table-schema.json",
         },
         {
             "name": "media",
@@ -604,7 +613,7 @@ datapackage = {
             "format": "csv",
             "mediatype": "text/csv",
             "encoding": "utf-8",
-            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/media-table-schema.json",
+            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/media-table-schema.json",
         },
         {
             "name": "observations",
@@ -613,15 +622,16 @@ datapackage = {
             "format": "csv",
             "mediatype": "text/csv",
             "encoding": "utf-8",
-            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/observations-table-schema.json",
+            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/observations-table-schema.json",
         },
     ],
+    "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/camtrap-dp-profile.json",
     "name": "flower-visitors-insectai-datathon",
     "created": datetime.now(timezone.utc).isoformat(),
     "contributors": [
         {
             "title": "Valentin Ștefan",
-            "role": "author",
+            "role": "contact",
             "email": "valentin.stefan@idiv.de",
         },
         {"title": "Aspen Workman", "role": "contributor"},
@@ -663,9 +673,9 @@ datapackage = {
             "all other orders (Diptera, Araneae, etc.) by Jared C. Cobain."
         ),
         "samplingDesign": "targeted",
-        "captureMethod": "timeLapse",
+        "captureMethod": ["timeLapse"],
         "individualAnimals": True,
-        "observationLevel": "media",
+        "observationLevel": ["media"],
     },
     "spatial": {
         "type": "Point",

--- a/datasets/flower_visitors/datapackage.json
+++ b/datasets/flower_visitors/datapackage.json
@@ -7,7 +7,7 @@
             "format": "csv",
             "mediatype": "text/csv",
             "encoding": "utf-8",
-            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/deployments-table-schema.json"
+            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/deployments-table-schema.json"
         },
         {
             "name": "media",
@@ -16,7 +16,7 @@
             "format": "csv",
             "mediatype": "text/csv",
             "encoding": "utf-8",
-            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/media-table-schema.json"
+            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/media-table-schema.json"
         },
         {
             "name": "observations",
@@ -25,15 +25,16 @@
             "format": "csv",
             "mediatype": "text/csv",
             "encoding": "utf-8",
-            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0/observations-table-schema.json"
+            "schema": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/observations-table-schema.json"
         }
     ],
+    "profile": "https://raw.githubusercontent.com/tdwg/camtrap-dp/1.0.2/camtrap-dp-profile.json",
     "name": "flower-visitors-insectai-datathon",
-    "created": "2026-04-21T13:52:24.061066+00:00",
+    "created": "2026-04-21T17:06:37.675596+00:00",
     "contributors": [
         {
             "title": "Valentin Ștefan",
-            "role": "author",
+            "role": "contact",
             "email": "valentin.stefan@idiv.de"
         },
         {
@@ -83,9 +84,13 @@
         "title": "Flower visitors (smartphone time-lapse subset)",
         "description": "Subset of arthropod flower-visit images collected via smartphone time-lapse photography in and around Leipzig/Halle, Germany. Full dataset: https://doi.org/10.5281/zenodo.15096610. Bounding boxes in observations.csv follow Camtrap DP 1.0 convention: normalized [0,1] coordinates (bboxX/Y/Width/Height) relative to the full-frame image, top-left anchor, xywh (x = left, y = top, width & height in the same normalized units). The original pixel bbox, the full-frame image dimensions, and the target-flower ROI crop region are preserved per-row in observationTags as bboxPx, imgSizePx, and roiPx. Insect identification credits: Hymenoptera by Aspen Workman; all other orders (Diptera, Araneae, etc.) by Jared C. Cobain.",
         "samplingDesign": "targeted",
-        "captureMethod": "timeLapse",
+        "captureMethod": [
+            "timeLapse"
+        ],
         "individualAnimals": true,
-        "observationLevel": "media"
+        "observationLevel": [
+            "media"
+        ]
     },
     "spatial": {
         "type": "Point",


### PR DESCRIPTION
  - Update schema URLs 1.0 -> 1.0.2 for deployments/media/observations
  - Add top-level profile URL required by validator
  - Fix contributor role (author -> contact; not in Camtrap DP enum)
  - Wrap project.captureMethod and project.observationLevel as arrays